### PR TITLE
Updated README to indicate that a call to super.onCreate is required …

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ public class IntroActivity extends OnboarderActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
     onboarderPages = new ArrayList<OnboarderPage>();
 
     // Create your first page


### PR DESCRIPTION
…to avoid an NPE

Issue: https://github.com/chyrta/AndroidOnboarder/issues/3

I was able to replicate the above issue by following the example in the README file, a call to super.onCreate(savedInstanceState) resolves that, I updated the readme file to reflect that change.
